### PR TITLE
Add additional schemas for DNA v0/1 and v2 based on v3 changes

### DIFF
--- a/ts/src/deps/schemas/aurory_dna_v0.5.0.json
+++ b/ts/src/deps/schemas/aurory_dna_v0.5.0.json
@@ -1,0 +1,254 @@
+{
+  "version": "0.5.0",
+  "version_date": "11/04/2023",
+  "global_genes_header": [
+    {
+      "name": "version",
+      "base": 2
+    },
+    {
+      "name": "category",
+      "base": 1
+    }
+  ],
+  "categories": {
+    "0": {
+      "name": "nefties",
+      "category_genes_header": [
+        {
+          "name": "archetype",
+          "base": 1
+        }
+      ],
+      "genes": [
+        {
+          "name": "hp",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "initiative",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "atk",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "def",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "eatk",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "edef",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "skill_a",
+          "base": 1,
+          "type": "index"
+        },
+        {
+          "name": "skill_b",
+          "base": 1,
+          "type": "index"
+        },
+        {
+          "name": "skill_c",
+          "base": 1,
+          "type": "index"
+        }
+      ],
+      "archetypes": {
+        "0": {
+          "fixed_attributes": {
+            "name": "Nefty_Bitebit",
+            "family": "Bitebit",
+            "mp": 4,
+            "passiveSkill": "bitebitPassive",
+            "ultimateSkill": "bouncingClaws"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [43, 52],
+            "eatk": [27, 33],
+            "edef": [43, 52],
+            "skill_a": ["backlineDrop"],
+            "skill_b": ["clashStance"],
+            "skill_c": ["LifeforceSink"]
+          }
+        },
+        "1": {
+          "fixed_attributes": {
+            "name": "Nefty_Dipking",
+            "family": "Dipking",
+            "mp": 3,
+            "passiveSkill": "SlipperySkin",
+            "ultimateSkill": "ComboBreaker"
+          },
+          "encoded_attributes": {
+            "hp": [410, 502],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [27, 33],
+            "eatk": [68, 83],
+            "edef": [34, 42],
+            "skill_a": ["EtherBlast"],
+            "skill_b": ["TankBuster"],
+            "skill_c": ["Dodge"]
+          }
+        },
+        "2": {
+          "fixed_attributes": {
+            "name": "Nefty_Dinobit",
+            "family": "Dinobit",
+            "mp": 2,
+            "passiveSkill": "dinobitPassive",
+            "ultimateSkill": "dinobit_bulldozer"
+          },
+          "encoded_attributes": {
+            "hp": [608, 743],
+            "initiative": [91, 109],
+            "atk": [43, 52],
+            "def": [68, 83],
+            "eatk": [27, 33],
+            "edef": [43, 52],
+            "skill_a": ["stompAttack"],
+            "skill_b": ["Throwback"],
+            "skill_c": ["NoEscape"]
+          }
+        },
+        "3": {
+          "fixed_attributes": {
+            "name": "Nefty_ShibaIgnite",
+            "family": "Shiba",
+            "mp": 2,
+            "passiveSkill": "shibaPassive",
+            "ultimateSkill": "bigBark"
+          },
+          "encoded_attributes": {
+            "hp": [533, 652],
+            "initiative": [91, 109],
+            "atk": [43, 52],
+            "def": [43, 52],
+            "eatk": [34, 42],
+            "edef": [43, 52],
+            "skill_a": ["ShoutBorn"],
+            "skill_b": ["BodyGuard"],
+            "skill_c": ["GroundControl"]
+          }
+        },
+        "4": {
+          "fixed_attributes": {
+            "name": "Nefty_Zzoo",
+            "family": "Zzoo",
+            "mp": 5,
+            "passiveSkill": "PainfulShriek",
+            "ultimateSkill": "FlyingDrop"
+          },
+          "encoded_attributes": {
+            "hp": [360, 440],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [27, 33],
+            "eatk": [43, 52],
+            "edef": [68, 83],
+            "skill_a": ["AttackAndBack"],
+            "skill_b": ["SharpGust"],
+            "skill_c": ["Overtake"]
+          }
+        },
+        "5": {
+          "fixed_attributes": {
+            "name": "Nefty_Blockchoy",
+            "family": "Blockchoy",
+            "mp": 3,
+            "passiveSkill": "FreshGreens",
+            "ultimateSkill": "Vitamins"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [34, 42],
+            "eatk": [54, 66],
+            "edef": [54, 66],
+            "skill_a": ["LifeCycle"],
+            "skill_b": ["AppeaseFeelings"],
+            "skill_c": ["RootsEmbrace"]
+          }
+        },
+        "6": {
+          "fixed_attributes": {
+            "name": "Nefty_Number9",
+            "family": "Number9",
+            "mp": 5,
+            "passiveSkill": "number9Passive",
+            "ultimateSkill": "JumpScare"
+          },
+          "encoded_attributes": {
+            "hp": [410, 502],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [68, 83],
+            "eatk": [68, 83],
+            "edef": [27, 33],
+            "skill_a": ["ScarringAttack"],
+            "skill_b": ["Pulltergeist"],
+            "skill_c": ["SoulConduit"]
+          }
+        },
+        "7": {
+          "fixed_attributes": {
+            "name": "Nefty_Axobubble",
+            "family": "Axobubble",
+            "mp": 3,
+            "passiveSkill": "tailekinesis",
+            "ultimateSkill": "bubbleOut"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [27, 33],
+            "eatk": [54, 66],
+            "edef": [68, 83],
+            "skill_a": ["pressureBomb"],
+            "skill_b": ["defensiveDome"],
+            "skill_c": ["fateSwap"]
+          }
+        },
+        "8": {
+          "fixed_attributes": {
+            "name": "Nefty_Unika",
+            "family": "Unika",
+            "mp": 4,
+            "passiveSkill": "Inspiring",
+            "ultimateSkill": "Encore"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [54, 66],
+            "def": [34, 42],
+            "eatk": [43, 52],
+            "edef": [34, 42],
+            "skill_a": ["RainbowFlash"],
+            "skill_b": ["ComeAndPlay"],
+            "skill_c": ["Kickback"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/ts/src/deps/schemas/aurory_dna_v2.1.0.json
+++ b/ts/src/deps/schemas/aurory_dna_v2.1.0.json
@@ -1,0 +1,265 @@
+{
+  "version": "2.1.0",
+  "version_date": "11/04/2023",
+  "global_genes_header": [
+    {
+      "name": "version",
+      "base": 2
+    },
+    {
+      "name": "category",
+      "base": 1
+    }
+  ],
+  "categories": {
+    "0": {
+      "name": "nefties",
+      "category_genes_header": [
+        {
+          "name": "archetype",
+          "base": 1
+        },
+        {
+          "name": "rarity",
+          "base": 1
+        }
+      ],
+      "genes": [
+        {
+          "name": "hp",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "initiative",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "atk",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "def",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "eatk",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "edef",
+          "base": 1,
+          "type": "range_completeness"
+        },
+        {
+          "name": "skill_a",
+          "base": 1,
+          "type": "index"
+        },
+        {
+          "name": "skill_b",
+          "base": 1,
+          "type": "index"
+        },
+        {
+          "name": "skill_c",
+          "base": 1,
+          "type": "index"
+        }
+      ],
+      "archetypes": {
+        "0": {
+          "fixed_attributes": {
+            "name": "Nefty_Bitebit",
+            "family": "Bitebit",
+            "mp": 4,
+            "passiveSkill": "bitebitPassive",
+            "ultimateSkill": "bouncingClaws"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [43, 52],
+            "eatk": [27, 33],
+            "edef": [43, 52],
+            "skill_a": ["backlineDrop"],
+            "skill_b": ["clashStance"],
+            "skill_c": ["LifeforceSink"]
+          }
+        },
+        "1": {
+          "fixed_attributes": {
+            "name": "Nefty_Dipking",
+            "family": "Dipking",
+            "mp": 3,
+            "passiveSkill": "SlipperySkin",
+            "ultimateSkill": "ComboBreaker"
+          },
+          "encoded_attributes": {
+            "hp": [410, 502],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [27, 33],
+            "eatk": [68, 83],
+            "edef": [34, 42],
+            "skill_a": ["EtherBlast"],
+            "skill_b": ["TankBuster"],
+            "skill_c": ["Dodge"]
+          }
+        },
+        "2": {
+          "fixed_attributes": {
+            "name": "Nefty_Dinobit",
+            "family": "Dinobit",
+            "mp": 2,
+            "passiveSkill": "dinobitPassive",
+            "ultimateSkill": "dinobit_bulldozer"
+          },
+          "encoded_attributes": {
+            "hp": [608, 743],
+            "initiative": [91, 109],
+            "atk": [43, 52],
+            "def": [68, 83],
+            "eatk": [27, 33],
+            "edef": [43, 52],
+            "skill_a": ["stompAttack"],
+            "skill_b": ["Throwback"],
+            "skill_c": ["NoEscape"]
+          }
+        },
+        "3": {
+          "fixed_attributes": {
+            "name": "Nefty_ShibaIgnite",
+            "family": "Shiba",
+            "mp": 2,
+            "passiveSkill": "shibaPassive",
+            "ultimateSkill": "bigBark"
+          },
+          "encoded_attributes": {
+            "hp": [533, 652],
+            "initiative": [91, 109],
+            "atk": [43, 52],
+            "def": [43, 52],
+            "eatk": [34, 42],
+            "edef": [43, 52],
+            "skill_a": ["ShoutBorn"],
+            "skill_b": ["BodyGuard"],
+            "skill_c": ["GroundControl"]
+          }
+        },
+        "4": {
+          "fixed_attributes": {
+            "name": "Nefty_Zzoo",
+            "family": "Zzoo",
+            "mp": 5,
+            "passiveSkill": "PainfulShriek",
+            "ultimateSkill": "FlyingDrop"
+          },
+          "encoded_attributes": {
+            "hp": [360, 440],
+            "initiative": [91, 109],
+            "atk": [68, 83],
+            "def": [27, 33],
+            "eatk": [43, 52],
+            "edef": [68, 83],
+            "skill_a": ["AttackAndBack"],
+            "skill_b": ["SharpGust"],
+            "skill_c": ["Overtake"]
+          }
+        },
+        "5": {
+          "fixed_attributes": {
+            "name": "Nefty_Blockchoy",
+            "family": "Blockchoy",
+            "mp": 3,
+            "passiveSkill": "FreshGreens",
+            "ultimateSkill": "Vitamins"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [34, 42],
+            "eatk": [54, 66],
+            "edef": [54, 66],
+            "skill_a": ["LifeCycle"],
+            "skill_b": ["AppeaseFeelings"],
+            "skill_c": ["RootsEmbrace"]
+          }
+        },
+        "6": {
+          "fixed_attributes": {
+            "name": "Nefty_Number9",
+            "family": "Number9",
+            "mp": 5,
+            "passiveSkill": "number9Passive",
+            "ultimateSkill": "JumpScare"
+          },
+          "encoded_attributes": {
+            "hp": [410, 502],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [68, 83],
+            "eatk": [68, 83],
+            "edef": [27, 33],
+            "skill_a": ["ScarringAttack"],
+            "skill_b": ["Pulltergeist"],
+            "skill_c": ["SoulConduit"]
+          }
+        },
+        "7": {
+          "fixed_attributes": {
+            "name": "Nefty_Axobubble",
+            "family": "Axobubble",
+            "mp": 3,
+            "passiveSkill": "tailekinesis",
+            "ultimateSkill": "bubbleOut"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [34, 42],
+            "def": [27, 33],
+            "eatk": [54, 66],
+            "edef": [68, 83],
+            "skill_a": ["pressureBomb"],
+            "skill_b": ["defensiveDome"],
+            "skill_c": ["fateSwap"]
+          }
+        },
+        "8": {
+          "fixed_attributes": {
+            "name": "Nefty_Unika",
+            "family": "Unika",
+            "mp": 4,
+            "passiveSkill": "Inspiring",
+            "ultimateSkill": "Encore"
+          },
+          "encoded_attributes": {
+            "hp": [468, 572],
+            "initiative": [91, 109],
+            "atk": [54, 66],
+            "def": [34, 42],
+            "eatk": [43, 52],
+            "edef": [34, 42],
+            "skill_a": ["RainbowFlash"],
+            "skill_b": ["ComeAndPlay"],
+            "skill_c": ["Kickback"]
+          }
+        }
+      }
+    }
+  },
+  "rarities": {
+    "0": "Common",
+    "1": "Uncommon",
+    "2": "Rare",
+    "3": "Epic",
+    "4": "Legendary"
+  }
+}

--- a/ts/src/dna_factory.ts
+++ b/ts/src/dna_factory.ts
@@ -23,7 +23,9 @@ import {
 import dnaSchemaV0_2 from './deps/schemas/aurory_dna_v0.2.0.json';
 import dnaSchemaV0_3 from './deps/schemas/aurory_dna_v0.3.0.json';
 import dnaSchemaV0_4 from './deps/schemas/aurory_dna_v0.4.0.json';
+import dnaSchemaV0_5 from './deps/schemas/aurory_dna_v0.5.0.json';
 import dnaSchemaV2_0 from './deps/schemas/aurory_dna_v2.0.0.json';
+import dnaSchemaV2_1 from './deps/schemas/aurory_dna_v2.1.0.json';
 import dnaSchemaV3_0 from './deps/schemas/aurory_dna_v3.0.0.json';
 import dnaSchemaV3_1 from './deps/schemas/aurory_dna_v3.1.0.json';
 import { LATEST_VERSION as LATEST_SCHEMA_VERSION } from './deps/schemas/latest';
@@ -41,7 +43,9 @@ const dnaSchemas: Record<version, DNASchema> = {
   '0.2.0': dnaSchemaV0_2 as DNASchema,
   '0.3.0': dnaSchemaV0_3 as DNASchema,
   '0.4.0': dnaSchemaV0_4 as DNASchema,
+  '0.5.0': dnaSchemaV0_5 as DNASchema,
   '2.0.0': dnaSchemaV2_0 as DNASchemaV2,
+  '2.1.0': dnaSchemaV2_1 as DNASchemaV2,
   '3.0.0': dnaSchemaV3_0 as DNASchemaV3,
   '3.1.0': dnaSchemaV3_1 as DNASchemaV3,
 };


### PR DESCRIPTION
- Reflect ether defense balance change for Dinobits with V0/V1/V2 DNA version strings as well